### PR TITLE
Replace panics with error logs, and nitpicks

### DIFF
--- a/src/commands/about.rs
+++ b/src/commands/about.rs
@@ -1,6 +1,6 @@
+use crate::util::split_authors;
 use serenity::builder::CreateApplicationCommand;
 use serenity::model::prelude::interaction::application_command::CommandDataOption;
-use crate::util::split_authors;
 
 trait NaIfNone {
     fn na(&self) -> String;


### PR DESCRIPTION
some `_` prefixed variables renamed to avoid confusion with an unused variable, [see here](https://runrust.miraheze.org/wiki/Underscore#Drop_order_for_wildcard_patterns)

Some `.unwrap()`s that could be avoided with a `return` statement were swapped out

Deliberate panic added if the conversion counter could not be created, that can be changed later (maybe disable the counter if it fails?)